### PR TITLE
fix: refactor instruction builder stopping seg fault

### DIFF
--- a/include/instructions.h
+++ b/include/instructions.h
@@ -2,15 +2,9 @@
 #define _PARSE_INSTRUCTIONS_H
 #include "op.h"
 
-typedef struct instruction {
-    int opcode;
-    char *operands;
-    struct instruction *next;
-} instruction_t;
+char **parse_instructions(char *instruction);
 
-char **parse_instruction(char *instruction);
-
-void build_instructions(champion_t *champ, char **instructions, instruction_t *inst);
+void build_instructions(champion_t *champ, char **instructions, instruction_t **inst_ptr);
 
 void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, int *instruction);
 

--- a/include/op.h
+++ b/include/op.h
@@ -89,7 +89,7 @@ typedef struct header_s {
 
 typedef struct instruction {
     int opcode;
-    char *operands;
+    int *operands;
     struct instruction *next;
 } instruction_t;
 
@@ -100,7 +100,6 @@ typedef struct champion {
   int counter;
   int carry_flag;
   int inst[MEM_SIZE + 1];
-  char **instructions;
   int instruction_size;
   instruction_t *instruction_list;
 } champion_t;

--- a/include/op.h
+++ b/include/op.h
@@ -87,6 +87,12 @@ typedef struct header_s {
   char comment[COMMENT_LENGTH + 1];         // Comment
 } header_t;
 
+typedef struct instruction {
+    int opcode;
+    char *operands;
+    struct instruction *next;
+} instruction_t;
+
 typedef struct champion {
   int id;
   header_t header;
@@ -94,8 +100,9 @@ typedef struct champion {
   int counter;
   int carry_flag;
   int inst[MEM_SIZE + 1];
-  char *instructions;
+  char **instructions;
   int instruction_size;
+  instruction_t *instruction_list;
 } champion_t;
 
 // Structure representing the core of the virtual machine

--- a/include/op.h
+++ b/include/op.h
@@ -26,24 +26,24 @@ enum parameter_types { T_REG = 1, T_DIR = 2, T_IND = 4, T_LAB = 8 };
 
 // Enumeration of operation types
 enum op_types {
-  OP_LIVE,
-  OP_LD,
-  OP_ST,
-  OP_ADD,
-  OP_SUB,
-  OP_AND,
-  OP_OR,
-  OP_XOR,
-  OP_ZJMP,
-  OP_LDI,
-  OP_STI,
-  OP_FORK,
-  OP_LLD,
-  OP_LLDI,
-  OP_LFORK,
-  OP_AFF,
-  OP_NOTHING,
-  OP_NB
+  OP_LIVE, // 0X01
+  OP_LD, // 0X02
+  OP_ST, // 0X03
+  OP_ADD, // 0X04
+  OP_SUB, // 0X05
+  OP_AND, // 0X06
+  OP_OR, // 0X07
+  OP_XOR, // 0X08
+  OP_ZJMP, // 0X09
+  OP_LDI, // 0X0A
+  OP_STI, // 0X0B
+  OP_FORK, // 0X0C
+  OP_LLD, // 0X0D
+  OP_LLDI, // 0X0E
+  OP_LFORK, // 0X0F
+  OP_AFF, // 0X10
+  OP_NOTHING, // 0X11
+  OP_NB // 0X12
 };
 
 // Size of indirect addressing mode in bytes

--- a/src/champion.c
+++ b/src/champion.c
@@ -5,6 +5,7 @@
 #include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../include/instructions.h"
 
 champion_t *init_champion() {
   champion_t *champ;
@@ -102,8 +103,12 @@ champion_t *create_champion(champion_t *champion, char *filename) {
     champion->instruction_size = j;
     printf("Hexadecimal representation: %s\n", hex_string);
   
-    champion->instructions = hex_string;
-    
+    char **parsed_instructions = parse_instructions(hex_string);
+    champion->instructions = parsed_instructions;
+    champion->instruction_list = NULL;
+    build_instructions(champion, champion->instructions, &champion->instruction_list);
+    free(parsed_instructions);
+
   } else {
       perror("Error getting file size");
   }

--- a/src/champion.c
+++ b/src/champion.c
@@ -104,9 +104,8 @@ champion_t *create_champion(champion_t *champion, char *filename) {
     printf("Hexadecimal representation: %s\n", hex_string);
   
     char **parsed_instructions = parse_instructions(hex_string);
-    champion->instructions = parsed_instructions;
     champion->instruction_list = NULL;
-    build_instructions(champion, champion->instructions, &champion->instruction_list);
+    build_instructions(champion, parsed_instructions, &champion->instruction_list);
     free(parsed_instructions);
 
   } else {
@@ -122,5 +121,4 @@ void add_champion(core_t *core_t, champion_t *champion) {
   core_t->champions[core_t->champion_count - 1] = *champion;
   champion->counter = 0;
   champion->carry_flag = 0;
-  champion->instructions = NULL;
 }

--- a/src/corewar.c
+++ b/src/corewar.c
@@ -12,24 +12,18 @@
 // TODO: are the vm and champs passed all the way down as pointers???
 void run_program(core_t *vm, champion_t champ) {
     UNUSED(vm);
-    printf("Running program: %s\n", champ.header.prog_name);
+    instruction_t *inst = champ.instruction_list;
 
-    char *instructions = champ.instructions;
-    instruction_t *inst = (instruction_t*)malloc(sizeof(instruction_t));
-
-    char **parsed_instructions = parse_instruction(instructions);
-
-    build_instructions(&champ, parsed_instructions, inst);
     while (inst->opcode != -1) {
         printf("Executing instruction: %s\n", op_tab[inst->opcode].mnemonique);
         int operands[op_tab[inst->opcode].nbr_args];
+
         for (int i = 0; i < op_tab[inst->opcode].nbr_args; i++) {
             operands[i] = atoi(&inst->operands[i]);
         }
         execute_instruction(vm, &champ, inst->opcode, operands);
         inst++;
     }
-    free(parsed_instructions);
 }
 
 int main(int ac, char **av) {
@@ -54,7 +48,6 @@ int main(int ac, char **av) {
         run_program(&vm, vm.champions[i]);
         i++;
     }
-    // run_program(&vm, *champ, program, program_size);
 
     return 0;
 }

--- a/src/corewar.c
+++ b/src/corewar.c
@@ -13,15 +13,14 @@
 void run_program(core_t *vm, champion_t champ) {
     UNUSED(vm);
     instruction_t *inst = champ.instruction_list;
-
-    while (inst->opcode != -1) {
+    while (inst != NULL && inst->opcode != -1) {
         printf("Executing instruction: %s\n", op_tab[inst->opcode].mnemonique);
-        int operands[op_tab[inst->opcode].nbr_args];
-
-        for (int i = 0; i < op_tab[inst->opcode].nbr_args; i++) {
-            operands[i] = atoi(&inst->operands[i]);
+        if (inst->opcode < 0 || inst->opcode >= 16) {
+            printf("Invalid opcode: %d\n", inst->opcode);
+            break;
         }
-        execute_instruction(vm, &champ, inst->opcode, operands);
+
+        execute_instruction(vm, &champ, inst->opcode, inst->operands);
         inst++;
     }
 }

--- a/src/corewar.c
+++ b/src/corewar.c
@@ -21,7 +21,7 @@ void run_program(core_t *vm, champion_t champ) {
         }
 
         execute_instruction(vm, &champ, inst->opcode, inst->operands);
-        inst++;
+        inst = inst->next;
     }
 }
 

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -5,7 +5,7 @@
 #include "../include/op.h"
 #include "../include/instructions.h"
 
-char **parse_instruction(char *instruction) {
+char **parse_instructions(char *instruction) {
     char **operands = malloc((MEM_SIZE + 1) * sizeof(char *)); 
     if (operands == NULL) {
         perror("Memory allocation failed");
@@ -30,7 +30,16 @@ char **parse_instruction(char *instruction) {
     return operands;
 }
 
-void build_instructions(champion_t *champ, char **instructions, instruction_t *inst) {
+void build_instructions(champion_t *champ, char **instructions, instruction_t **inst_ptr) {
+    instruction_t *inst = *inst_ptr;
+    if (inst == NULL) {
+        inst = (instruction_t*)malloc(sizeof(instruction_t));
+        if (inst == NULL) {
+            perror("Memory allocation failed");
+            exit(EXIT_FAILURE);
+        }
+        *inst_ptr = inst;
+    }
     printf("Building instruction: %s\n", *instructions);
     enum op_types opcode = (enum op_types)strtoul(*instructions, NULL, 16);
     if (opcode < 1 || opcode > 16) {
@@ -38,21 +47,20 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t *i
         inst->next = NULL;
     } else {
         op_t operation = op_tab[opcode - 1];
-        printf("opcode: %d, mnemonic: %s, args: %d\n", opcode, operation.mnemonique, operation.nbr_args);
-
         int operation_args = operation.nbr_args;
-        inst->opcode = opcode - 1;
         inst->operands = (char*)malloc((operation_args + 1) * sizeof(char));
-
         if (inst->operands == NULL) {
             perror("Memory allocation failed");
             exit(EXIT_FAILURE);
         }
+        inst->opcode = opcode - 1;
 
         int i = 0;
-        while (i < operation_args + 2) {
+        printf("opcode: %d, mnemonic: %s, args: %d\n", opcode, operation.mnemonique, operation_args);
+        while (i < operation_args) {
             if (*instructions != NULL) { 
                 inst->operands[i] = **instructions;
+
                 instructions++;
                 i++;
             } else {
@@ -63,12 +71,14 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t *i
         inst->operands[i] = '\0';
 
         if (*instructions != NULL) {
-            inst->next = (instruction_t*)malloc(sizeof(instruction_t));
-            if (inst->next == NULL) {
+            instruction_t *next_inst = (instruction_t*)malloc(sizeof(instruction_t));            
+            if (next_inst == NULL) {
                 perror("Memory allocation failed");
                 exit(EXIT_FAILURE);
             }
-            build_instructions(champ, instructions, inst->next);
+            inst->next = next_inst;
+
+            build_instructions(champ, instructions, &next_inst);
         } else {
             inst->next = NULL;
         }
@@ -80,7 +90,6 @@ void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, in
     
     if (operation->inst != NULL) {
         printf("calling operation: %s\n", operation->mnemonique);
-        // TODO: this might not be the correct way to pass operand??
         operation->inst(champ, vm, opcode, instruction);
     } else {
         printf("Unknown or unimplemented operation\n");

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -48,7 +48,7 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t **
     } else {
         op_t operation = op_tab[opcode - 1];
         int operation_args = operation.nbr_args;
-        inst->operands = (int*)malloc((operation_args + 1) * sizeof(int));
+        inst->operands = (int*)malloc((operation_args) * sizeof(int));
         if (inst->operands == NULL) {
             perror("Memory allocation failed");
             exit(EXIT_FAILURE);
@@ -57,8 +57,14 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t **
 
         int i = 0;
         printf("opcode: %d, mnemonic: %s, args: %d\n", opcode, operation.mnemonique, operation_args);
-        while (i < operation_args) {
+        while (i < operation_args + 2) {
             if (*instructions != NULL) { 
+                if (i == 0 || i == 1) {
+                    instructions++;
+                    i++;
+                    continue;
+                }
+                printf("operand: %s\n", *instructions);
                 long int operandValue = strtol(*instructions, NULL, 10);
                 if (operandValue == 0 && **instructions != '0') {
                     printf("Invalid operand: %s\n", *instructions);
@@ -77,8 +83,6 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t **
                 break;
             }
         }
-
-        inst->operands[i] = '\0';
 
         if (*instructions != NULL) {
             instruction_t *next_inst = (instruction_t*)malloc(sizeof(instruction_t));            

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -48,7 +48,7 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t **
     } else {
         op_t operation = op_tab[opcode - 1];
         int operation_args = operation.nbr_args;
-        inst->operands = (char*)malloc((operation_args + 1) * sizeof(char));
+        inst->operands = (int*)malloc((operation_args + 1) * sizeof(int));
         if (inst->operands == NULL) {
             perror("Memory allocation failed");
             exit(EXIT_FAILURE);
@@ -59,7 +59,17 @@ void build_instructions(champion_t *champ, char **instructions, instruction_t **
         printf("opcode: %d, mnemonic: %s, args: %d\n", opcode, operation.mnemonique, operation_args);
         while (i < operation_args) {
             if (*instructions != NULL) { 
-                inst->operands[i] = **instructions;
+                long int operandValue = strtol(*instructions, NULL, 10);
+                if (operandValue == 0 && **instructions != '0') {
+                    printf("Invalid operand: %s\n", *instructions);
+                    break;
+                } else if (operandValue < 0 || operandValue > 100) {
+                    printf("Invalid register: %ld\n", operandValue);
+                    break;
+                } else {
+                    inst->operands[i] = (char)operandValue;
+                }
+
 
                 instructions++;
                 i++;


### PR DESCRIPTION
### What was done?

- parse and build instructions on create of champion
- cleaned up champions struct for unused `char *instructions`
- cleaned up corewars.c slightly from leftover code

### :tophat: Instructions

- `./build/corewar players/simple_2.cor players/simple_2.cor players/simple_2.cor  players/simple_2.cor` should successfully build four champions and run each program consecutively

**Note: there is an occasional failure (see below error message) something to watch out for and determine how to fix**

```
Starting corewar
Loading champion: players/simple_2.cor
File size of players/simple_2.cor: 2215 bytes
Magic value equals 0xea83f3!
Program name: Simple
Program size: 23
Comment: Let's get started
Hexadecimal representation: 0b 68 01 0f 01 06 64 01 01 01 01 09 Vf Vb 
Building instruction: 0b
opcode: 11, mnemonic: sti, args: 3
operand: 01
operand: 0f
operand: 01
corewar(4229,0x7ff85366e640) malloc: Incorrect checksum for freed object 0x7fae73f05c70: probably modified after being freed.
Corrupt value: 0x6000000000000001
corewar(4229,0x7ff85366e640) malloc: *** set a breakpoint in malloc_error_break to debug
[1]    4229 abort      ./build/corewar players/simple_2.cor players/simple_2.cor players/simple_2.co
```