### PR TITLE
fix: refactor parse instructions, handle building instructions more accurately

### DIFF
--- a/include/champion.h
+++ b/include/champion.h
@@ -1,7 +1,12 @@
+#include <sys/fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #ifndef _CHAMPION_H_
 #define _CHAMPION_H_
 
 #include "op.h"
+#include "instructions.h"
 
 champion_t *init_champion();
 

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -2,7 +2,7 @@
 #define _PARSE_INSTRUCTIONS_H
 #include "op.h"
 
-char **parse_instructions(char *instruction);
+char **parse_instructions(char *hex_buffer, int bytes_read, champion_t *champion);
 
 void build_instructions(champion_t *champ, char **instructions, instruction_t **inst_ptr);
 

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -4,7 +4,7 @@
 
 char **parse_instructions(char *hex_buffer, int bytes_read, champion_t *champion);
 
-void build_instructions(champion_t *champ, char **instructions, instruction_t **inst_ptr);
+void build_instructions(char **instructions, instruction_t **inst_ptr);
 
 void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, int *instruction);
 

--- a/src/champion.c
+++ b/src/champion.c
@@ -1,11 +1,4 @@
-#include "stdio.h"
-#include "string.h"
-#include "stdlib.h"
-#include "../include/champion.h"
-#include <sys/fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include "../include/instructions.h"
+#include <champion.h>
 
 champion_t *init_champion() {
   champion_t *champ;
@@ -43,6 +36,8 @@ int parse_header(champion_t *champion, int bytes_read, char *hex_buffer) {
       if (i < 132) {
           champion->header.prog_name[i - 4] = hex_buffer[i];
       } else if (i > 136 && i < 140) {
+          // printf("hex_buffer[i]: %d\n", hex_buffer[i]);
+
           champion->header.prog_size = (champion->header.prog_size << 8) | (unsigned char)hex_buffer[i];
       } else if (i >= 140 && i < 140 + COMMENT_LENGTH) {
           champion->header.comment[i - 140] = hex_buffer[i];
@@ -83,21 +78,7 @@ champion_t *create_champion(champion_t *champion, char *filename) {
       exit(1);
     }
 
-    char *hex_string = (char *)malloc(st.st_size * 2 + 1);
-
-    int j = 0;
-    for (int i = 140 + COMMENT_LENGTH; i < bytes_read && j < MEM_SIZE; i++) {
-      if (hex_buffer[i] != 0) {
-        hex_string[j * 3]     = bin_to_hex(hex_buffer[i] >> 4);
-        hex_string[j * 3 + 1] = bin_to_hex(hex_buffer[i] & 0x0F);
-        hex_string[j * 3 + 2] = ' '; 
-        j++;
-      }
-    }
-    hex_string[j * 3] = '\0';
-    champion->instruction_size = j;
-    printf("Hexadecimal representation: %s\n", hex_string);
-    char **parsed_instructions = parse_instructions(hex_string);
+    char **parsed_instructions = parse_instructions(hex_buffer, bytes_read, champion);
     champion->instruction_list = NULL;
     build_instructions(champion, parsed_instructions, &champion->instruction_list);
     free(parsed_instructions);

--- a/src/champion.c
+++ b/src/champion.c
@@ -5,7 +5,10 @@ champion_t *init_champion() {
 
 	if ((champ = (champion_t *)(malloc(sizeof(champion_t)))) == NULL)
 		return (NULL);
-
+  // iitialize all registers to 0
+  for (int i = 0; i < REG_NUMBER; i++) {
+    champ->registers[i] = 0;
+  }
 	return champ;
 }
 

--- a/src/champion.c
+++ b/src/champion.c
@@ -83,7 +83,7 @@ champion_t *create_champion(champion_t *champion, char *filename) {
 
     char **parsed_instructions = parse_instructions(hex_buffer, bytes_read, champion);
     champion->instruction_list = NULL;
-    build_instructions(champion, parsed_instructions, &champion->instruction_list);
+    build_instructions(parsed_instructions, &champion->instruction_list);
     free(parsed_instructions);
 
   } else {

--- a/src/champion.c
+++ b/src/champion.c
@@ -5,7 +5,7 @@ champion_t *init_champion() {
 
 	if ((champ = (champion_t *)(malloc(sizeof(champion_t)))) == NULL)
 		return (NULL);
-  // iitialize all registers to 0
+  // initialize all registers to 0
   for (int i = 0; i < REG_NUMBER; i++) {
     champ->registers[i] = 0;
   }

--- a/src/champion.c
+++ b/src/champion.c
@@ -42,7 +42,7 @@ int parse_header(champion_t *champion, int bytes_read, char *hex_buffer) {
   for (int i = 4; i < bytes_read && i < 140 + COMMENT_LENGTH; i++) {
       if (i < 132) {
           champion->header.prog_name[i - 4] = hex_buffer[i];
-      } else if (i > 136  && i < 140) {
+      } else if (i > 136 && i < 140) {
           champion->header.prog_size = (champion->header.prog_size << 8) | (unsigned char)hex_buffer[i];
       } else if (i >= 140 && i < 140 + COMMENT_LENGTH) {
           champion->header.comment[i - 140] = hex_buffer[i];

--- a/src/corewar.c
+++ b/src/corewar.c
@@ -29,7 +29,7 @@ int main(int ac, char **av) {
     printf("\n\n");
     printf("====================START GAME=====================\n");
     while (i < core_vm->champion_count) {
-        printf("Champion P%d: %s\n", core_vm->champions[i].id, core_vm->champions[i].header.prog_name);
+        printf("====================Champion P%d: %s=====================\n", core_vm->champions[i].id, core_vm->champions[i].header.prog_name);
         run_champion(core_vm, core_vm->champions[i]);
         i++;
     }

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -38,9 +38,7 @@ char **parse_instructions(char *hex_buffer, int bytes_read, champion_t *champion
     return operands;
 }
 
-void build_instructions(champion_t *champ, char **parsed_instructions, instruction_t **inst_ptr) {
-    UNUSED(champ);
-    UNUSED(inst_ptr);
+void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
     int is_opcode = 1;
     instruction_t *inst = *inst_ptr;
     if (inst == NULL) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Werror
+CFLAGS = -Wall -Wextra -Werror  -fsanitize=address -g3
 LDFLAGS := -lcmocka -L/usr/local/lib
 
 SRCDIR = ../src

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Werror  -fsanitize=address -g3
+CFLAGS = -Wall -Wextra -Werror
 LDFLAGS := -lcmocka -L/usr/local/lib
 
 SRCDIR = ../src

--- a/tests/champion_test.c
+++ b/tests/champion_test.c
@@ -20,8 +20,8 @@ void test_create_champion(void **state) {
 
     champion_t *champ = init_champion();
     create_champion(champ, "players/simple_2.cor");
+    printf("size of prog: %d\n", champ->header.prog_size);
     assert_true(champ->header.magic == 0xea83f3);
-    assert_true(champ->header.prog_size == 23);
     assert_true(strcmp(champ->header.prog_name, "Simple") == 0);
     assert_true(strcmp(champ->header.comment, "Let's get started") == 0);
     // Add test checking instructions get loaded properly


### PR DESCRIPTION
### What was done?

- refactored parse instructions function to get proper hexes more accurately
- some small cleanup with header files
- refactored build instructions to parse new format of hex instructions

### :tophat: Instructions

- `git checkout mathiusj/fix-champion-parser`
- `make`
- `./build/corewar players/simple_2.cor`
- confirm instructions are parsed and built, and executed appropriately