### PR TITLE
fix: improve instruction compiling and parsing

### DIFF
--- a/assembler/compiler.c
+++ b/assembler/compiler.c
@@ -1,20 +1,15 @@
 #include "./op.h"
 
-// Main assembler loop with two passes
 void assemble(FILE *input, FILE *output) {
     char line[MAX_LINE_LENGTH];
-    int current_address = 0; // Start address for the code
+    int current_address = 0; 
 
-    // First pass: Build the symbol table
     while (fgets(line, sizeof(line), input)) {
         ParsedLine parsedLine = parse_line(line);
         if (parsedLine.lineType == TOKEN_LABEL) {
             add_symbol(parsedLine.label, current_address);
         } else if (parsedLine.lineType == TOKEN_INSTRUCTION) {
-            // Here you'd calculate the size of the instruction and increment current_address
-
-            // For now, we'll just increment it by a placeholder value
-            current_address += 4; // Placeholder, replace with actual instruction size
+            current_address += 4;
         }
     }
 
@@ -55,7 +50,10 @@ void write_program_size(FILE *input, FILE *output_file) {
         }
     }
 
-    fwrite(&program_size, sizeof(int), 1, output_file);
+    unsigned int big_endian_value = htonl(program_size);
+
+
+    fwrite(&big_endian_value, sizeof(int), 1, output_file);
 
 }
 

--- a/assembler/encode_instructions.c
+++ b/assembler/encode_instructions.c
@@ -19,11 +19,11 @@ void encode_direct(FILE *output, const char *arg) {
 int containsDigits(const char *str) {
     while (*str != '\0') {
         if (isdigit(*str)) {
-            return 1; // Return true if a digit is found
+            return 1; 
         }
-        str++; // Move to the next character
+        str++; 
     }
-    return 0; // Return false if no digits are found
+    return 0;
 }
 
 void encode_indirect(FILE *output, const char *arg, int current_address) {

--- a/assembler/encode_instructions.c
+++ b/assembler/encode_instructions.c
@@ -35,7 +35,7 @@ void encode_indirect(FILE *output, const char *arg, int current_address) {
     } else if (arg[0] == '%' && containsDigits(arg + 1) == 1) {
         indirect_value = atoi(arg + 1); // Skip '%' and convert to int
     } else {
-        printf("arg: %s\n", arg);
+        printf("arg in indirect: %s\n", arg);
         // Handle as numeric offset
         indirect_value = atoi(arg);
     }
@@ -103,7 +103,7 @@ void encode_instruction(FILE *output, ParsedLine *parsedLine) {
 
         // Trim leading whitespace
         while (isspace((unsigned char)*arg)) { arg++; }
-        printf("arg: %s\n", arg);
+        printf("arg in encode: %s\n", arg);
         if (*arg == 'r') {
             // Write register (1 byte)
             printf("register: %s\n", arg);

--- a/assembler/lex_token.c
+++ b/assembler/lex_token.c
@@ -45,7 +45,9 @@ Token lex_token(const char **input) {
             strncpy(token.string, start, length);
             token.string[length] = '\0';
         }
-    } else if (isalpha((unsigned char)**input)) { // Label or Instruction
+    } else if (isalpha((unsigned char)**input) && *input[0] != 'r') { // Label or Instruction
+        printf("input in alpha: %s\n", *input);
+
         start = *input;
         while (isalnum((unsigned char)**input) || **input == '_') {
             (*input)++;
@@ -60,6 +62,7 @@ Token lex_token(const char **input) {
         strncpy(token.string, start, length);
         token.string[length] = '\0';
     } else if (isdigit((unsigned char)**input) || **input == '-') { // Number
+        printf("input from digit: %s\n", *input);
         token.type = TOKEN_NUMBER;
         if (**input == '-') {
             (*input)++;
@@ -70,10 +73,11 @@ Token lex_token(const char **input) {
         size_t length = *input - start;
         strncpy(token.string, start, length);
         token.string[length] = '\0';
-    } else if (**input == 'r' && isdigit((unsigned char)*(*input + 1))) { // Register
+    } else if (*input[0] == 'r' && isdigit((unsigned char)*(*input + 1))) { // Register
         token.type = TOKEN_REGISTER;
-        (*input)++; // Skip 'r'
+        printf("input from r: %s\n", *input);
         start = *input; // Start at the digit
+        (*input)++; // Skip 'r'
         while (isdigit((unsigned char)**input)) {
             (*input)++;
         }
@@ -106,7 +110,8 @@ Token lex_token(const char **input) {
         token.type = TOKEN_SEPARATOR;
         (*input)++;  // Skip the comma
     }
-    else if (**input == 'r' && isdigit((unsigned char)*(*input + 1))) { // Register
+    else if (*input[0] == 'r' && isdigit((unsigned char)*(*input + 1))) { // Register
+        printf("input: %s\n", *input);
         token.type = TOKEN_REGISTER;
         (*input)++; // Skip 'r'
         start = *input; // Start at the digit

--- a/assembler/parse_line.c
+++ b/assembler/parse_line.c
@@ -29,8 +29,10 @@ ParsedLine parse_line(const char *line) {
 
     // Process arguments if any
     while ((token = lex_token(&inputPtr)).type != TOKEN_ENDLINE && token.type != TOKEN_COMMENT) {
-        if (parsedLine.argumentCount < MAX_ARGS_NUMBER) {
-            strcpy(parsedLine.arguments[parsedLine.argumentCount++], token.string);
+        if (parsedLine.argumentCount < MAX_ARGS_NUMBER && token.string[0] != '\0') {
+            printf("arg in while: %s\n", token.string);
+            strcpy(parsedLine.arguments[parsedLine.argumentCount], token.string);
+            parsedLine.argumentCount++;
         } else {
             // Handle error: too many arguments
         }

--- a/src/champion.c
+++ b/src/champion.c
@@ -119,21 +119,6 @@ void add_champion(core_t *core_t, champion_t *champion) {
 void run_champion(core_t *vm, champion_t champion) {
     instruction_t *inst = champion.instruction_list;
     while (inst != NULL && inst->opcode != -1) {
-        printf("instruction from run_program: %s\n", op_tab[inst->opcode].mnemonique);
-
-        if (inst->operands != NULL) {
-          int i = 0;
-          printf("operands in run champion: ");
-          while (i < op_tab[inst->opcode].nbr_args) {
-              if (inst->operands[i] < 0 || inst->operands[i] >= MEM_SIZE) {
-                printf("Invalid operand: %d\n", inst->operands[i]);
-                return;
-              }
-              printf("%d ", inst->operands[i]);
-              i++;
-          }
-        }
-        printf("\n");
         execute_instruction(vm, &champion, inst->opcode, inst->operands);
         inst = inst->next;
     }

--- a/src/champion.c
+++ b/src/champion.c
@@ -119,10 +119,6 @@ void add_champion(core_t *core_t, champion_t *champion) {
 void run_champion(core_t *vm, champion_t champion) {
     instruction_t *inst = champion.instruction_list;
     while (inst != NULL && inst->opcode != -1) {
-        if (inst->opcode < 0 || inst->opcode >= 16) {
-            printf("Invalid opcode: %d\n", inst->opcode);
-            break;
-        }
         printf("instruction from run_program: %s\n", op_tab[inst->opcode].mnemonique);
 
         if (inst->operands != NULL) {

--- a/src/champion.c
+++ b/src/champion.c
@@ -9,7 +9,6 @@ void load_champions(core_t *core_vm, int ac, char **av) {
     add_champion(core_vm, champ);
     ac--;
   }
-
 }
 
 champion_t *init_champion() {
@@ -48,12 +47,15 @@ int parse_header(champion_t *champion, int bytes_read, char *hex_buffer) {
   }
 
   for (int i = 4; i < bytes_read && i < 140 + COMMENT_LENGTH; i++) {
-      if (i < 132) {
+      if (i < PROG_NAME_LENGTH + 4) {
           champion->header.prog_name[i - 4] = hex_buffer[i];
-      } else if (i > 136 && i < 140) {
-          // printf("hex_buffer[i]: %d\n", hex_buffer[i]);
-
-          champion->header.prog_size = (champion->header.prog_size << 8) | (unsigned char)hex_buffer[i];
+      } else if (i > PROG_NAME_LENGTH && i < PROG_NAME_LENGTH + 8) {
+          while (hex_buffer[i] == 00) { 
+              i++;
+          }
+          char *hex_value = (char*)malloc(3 * sizeof(char));
+          snprintf(hex_value, 3, "%.2x", (unsigned int)hex_buffer[i]);
+          champion->header.prog_size = strtol(hex_value, NULL, 16);
       } else if (i >= 140 && i < 140 + COMMENT_LENGTH) {
           champion->header.comment[i - 140] = hex_buffer[i];
       }

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -60,7 +60,7 @@ instruction_t *check_next_instruction(const char *parsed_instruction, instructio
 int build_opcode(const char *parsed_instruction, instruction_t *inst) {
     enum op_types opcode = (enum op_types)strtol(parsed_instruction, NULL, 16);
     printf("opcode: %d\n", opcode);
-    if (opcode - 1 < 0 || opcode - 1 > 16) {
+    if ((int)opcode - 1 < 0 || (int)opcode - 1 > 16) {
         printf("Invalid opcode: %d\n", opcode);
         return 1;
     }

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -2,7 +2,6 @@
 #include "../include/instructions.h"
 
 void print_operands(char **operands) {
-    printf("Hexadecimal operands\n");
     int j = 0;
     while (operands[j] != NULL) {
       printf("%s ", operands[j]);
@@ -38,6 +37,8 @@ char **parse_instructions(const char *hex_buffer, int bytes_read, champion_t *ch
     }
     operands[j] = NULL;
     champion->instruction_size = j;
+    printf("Hexadecimal operands\n");
+
     print_operands(operands);
     return operands;
 }
@@ -142,20 +143,10 @@ void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
     }
 }
 
-void print_args(const int *args, int count) {
-    printf("args in execute: ");
-    for (int i = 0; i < count; i++) {
-        printf("%d ", args[i]);
-    }
-    printf("\n");
-}
-
 void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, int *args) {
     const op_t *operation = &op_tab[opcode];
-    print_args(args, operation->nbr_args);
     
     if (operation->inst != NULL) {
-        printf("executing operation: %s\n", operation->mnemonique);
         operation->inst(champ, vm, opcode, args);
     } else {
         printf("Unknown or unimplemented operation\n");

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -102,8 +102,7 @@ int *parse_operands(char **parsed_instructions, int *i, int opcode) {
     return operands;
 }
 
-void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
-    int is_opcode = 1;
+instruction_t *allocate_instruction(instruction_t **inst_ptr) {
     instruction_t *inst = *inst_ptr;
     if (inst == NULL) {
         inst = (instruction_t*)malloc(sizeof(instruction_t));
@@ -113,6 +112,12 @@ void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
         }
         *inst_ptr = inst;
     }
+    return inst;
+}
+
+void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
+    int is_opcode = 1;
+    instruction_t *inst = allocate_instruction(inst_ptr);
     int i = 0;
 
     while (parsed_instructions[i] != NULL) {

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -142,19 +142,17 @@ void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
     }
 }
 
-void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, int *args) {
-    int i = 0;
-    const op_t *operation = &op_tab[opcode];
-    printf("args in execute instructions: ");
-    while (i < operation->nbr_args) {
-        if (args[i] < 0 || args[i] > 100) {
-            printf("Invalid instruction: %d\n", args[i]);
-            return;
-        }
+void print_args(const int *args, int count) {
+    printf("args in execute: ");
+    for (int i = 0; i < count; i++) {
         printf("%d ", args[i]);
-        i++;
     }
     printf("\n");
+}
+
+void execute_instruction(core_t *vm, champion_t *champ, enum op_types opcode, int *args) {
+    const op_t *operation = &op_tab[opcode];
+    print_args(args, operation->nbr_args);
     
     if (operation->inst != NULL) {
         printf("executing operation: %s\n", operation->mnemonique);

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -56,14 +56,17 @@ void build_instructions(char **parsed_instructions, instruction_t **inst_ptr) {
     int i = 0;
 
     while (parsed_instructions[i] != NULL) {
-        if (is_opcode == 1) {
-            is_opcode = 0;
+        printf("parsed instruction: %s\n", parsed_instructions[i]);
+        if (is_opcode == 1 && strcmp(parsed_instructions[i], "00") != 0) {
             enum op_types opcode = (enum op_types)strtol(parsed_instructions[i], NULL, 16);
-            inst->opcode = opcode - 1;
+            printf("opcode: %d\n", opcode);
+            inst->opcode = opcode -1;
+            is_opcode = 0;
         } else {
             if (inst->opcode < 0 || inst->opcode > 16) {
                 printf("Invalid opcode: %d\n", inst->opcode);
-                break;
+                i++;
+                continue;
             }
             op_t operation = op_tab[inst->opcode];
             

--- a/src/operations/utils.c
+++ b/src/operations/utils.c
@@ -3,11 +3,10 @@
 
 void log_instruction_args(const champion_t *champion, const core_t *core, code_t code, int *inst) {
   const op_t *operation = &op_tab[code];
-
+  UNUSED(champion);
+  UNUSED(core);
+  
   printf("====================called %s with:=====================\n", operation->mnemonique);
-  printf("champion: %p\n", &champion);
-  printf("core: %p\n", &core);
-  printf("code: %p\n", &code);
   int i = 0;
   printf("args in execute instructions: ");
   while (i < operation->nbr_args) {


### PR DESCRIPTION
### What was done?

- some updates on both compiler and parser side of things to better build instructions
- handling registers more explicitly
- skipping the encoding of empty strings

### :tophat: Instructions

- `make`
- `./build/compiler ../players/simple.s ../players/simple.cor`
- confirm instructions look as expected in hex rep

TODO: fix bug on parsing side causing seg fault...