### PR TITLE
fix: handle compiling and parsing instructions more accurately

### DIFF
--- a/assembler/compiler.c
+++ b/assembler/compiler.c
@@ -82,10 +82,12 @@ int main(int argc, const char *argv[]) {
     write_magic_number(output_file);
 
     fwrite(header.name, sizeof(char), sizeof(char) * PROG_NAME_LENGTH, output_file);
+    fwrite("\0\0\0\0", sizeof(char), 4, output_file); // Placeholder for program instructions size (4 bytes)
+
     write_program_size(input_file, output_file);
 
     fwrite(header.comment, sizeof(char), sizeof(char) * COMMENT_LENGTH, output_file);
-    fwrite("\0\0\0\0\0\0\0\0", sizeof(char), 8, output_file); // Placeholder for program instructions size (4 bytes)
+    fwrite("\0\0\0\0", sizeof(char), 4, output_file); // Placeholder for program instructions size (4 bytes)
 
     assemble(input_file, output_file);
 

--- a/src/champion.c
+++ b/src/champion.c
@@ -83,7 +83,7 @@ champion_t *create_champion(champion_t *champion, char *filename) {
 
   if (stat(filename, &st) == 0) {
     char hex_buffer[st.st_size];
-    int bytes_read = read(fd, hex_buffer, sizeof(hex_buffer) - 1);
+    int bytes_read = read(fd, hex_buffer, sizeof(hex_buffer));
 
     if (bytes_read == -1) {
       printf("Error: could not read file\n");
@@ -118,7 +118,7 @@ void add_champion(core_t *core_t, champion_t *champion) {
 
 void run_champion(core_t *vm, champion_t champion) {
     instruction_t *inst = champion.instruction_list;
-    while (inst != NULL && inst->opcode != -1) {
+    while (inst != NULL && inst->opcode >= 0 && inst->opcode <= 15) {
         execute_instruction(vm, &champion, inst->opcode, inst->operands);
         inst = inst->next;
     }

--- a/src/champion.c
+++ b/src/champion.c
@@ -56,8 +56,8 @@ int parse_header(champion_t *champion, int bytes_read, char *hex_buffer) {
           char *hex_value = (char*)malloc(3 * sizeof(char));
           snprintf(hex_value, 3, "%.2x", (unsigned int)hex_buffer[i]);
           champion->header.prog_size = strtol(hex_value, NULL, 16);
-      } else if (i >= 140 && i < 140 + COMMENT_LENGTH) {
-          champion->header.comment[i - 140] = hex_buffer[i];
+      } else if (i >= PROG_NAME_LENGTH + 12 && i < PROG_NAME_LENGTH + 12 + COMMENT_LENGTH) {
+          champion->header.comment[i - (PROG_NAME_LENGTH + 12)] = hex_buffer[i];
       }
   }
   printf("Program name: %s\n", champion->header.prog_name);

--- a/src/game.c
+++ b/src/game.c
@@ -1,13 +1,49 @@
 #include <game.h>
 #include <champion.h>
 
+/**
+ *  Phase 4: we want each champion to ONLY call one instruction per turn. EG:
+ *  Define the number of instructions that each champion should run
+ * const numberOfInstructions = core.champions[0].instructions.length;
+
+ Game loop 1
+ champion 1 executes inst 1,
+ champion 2 executes inst 1,
+ champion 3 executes inst 1,
+ Game loop 2
+ champion 1 executes inst 2,
+ champion 2 executes inst 2,
+ champion 3 executes inst 2,
+ Game loop 3
+ champion 1 executes inst 3,
+ champion 2 executes inst 3,
+ champion 3 executes inst 3,
+ looping through each instruction
+ for (let gameloopNumber = 0; gameloopNumber < numberOfLoops; gameloopNumber++){
+    looping through each champion
+   for (let championNumber = 0; championNumber < core.champions.length; championNumber++){
+      get the current champion
+     const champion = core.champions[championNumber];
+
+      get the instruction for the current champion
+     const instruction = champion.instructions[gameloopNumber] 
+     console.log(`champion ${champion.name} is executing: ` )
+     instruction();
+   }
+ }
+ * 
+*/
+
 void run_game(core_t *core_vm) {
     int i = 0;
     printf("\n\n");
     printf("====================START GAME=====================\n");
+    // Have to create a game loop just like the one in the snippet above that will loop through each champion and execute one instruction at a time
     while (i < core_vm->champion_count) {
-        printf("====================Champion P%d: %s=====================\n", core_vm->champions[i].id, core_vm->champions[i].header.prog_name);
+        printf("====================Champion P%d: %s executes=====================\n", core_vm->champions[i].id, core_vm->champions[i].header.prog_name);
+        // need to modify run champion to only run one instruction at a time based on current game_loop_number
         run_champion(core_vm, core_vm->champions[i]);
         i++;
+
     }
 }


### PR DESCRIPTION
### What was done?

closes https://github.com/yogimathius/core-wars/issues/76
closes https://github.com/yogimathius/core-wars/issues/77

### :tophat: Instructions

- `cd assembler`
- `make`
- `./build/compiler ../players/simple.s ../players/simple.cor`
- `cd ..`
- `make`
- ./build/corewar players/simple.cor`
- ensure all instructions correctly parsed and executed:
```
====================called sub with:=====================
args in execute instructions: 4 5 6 
```