### PR TITLE
feat: handle parsing labels and jumps

### DIFF
--- a/include/op.h
+++ b/include/op.h
@@ -87,15 +87,23 @@ enum registers {
 
 // Header structure for the program
 typedef struct header_s {
-  int magic;                                // Magic number
-  char prog_name[PROG_NAME_LENGTH + 1];     // Program name
-  int prog_size;                            // Program size
-  char comment[COMMENT_LENGTH + 1];         // Comment
+  int magic; 
+  char prog_name[PROG_NAME_LENGTH + 1];
+  int prog_size;
+  char comment[COMMENT_LENGTH + 1];
 } header_t;
+
+typedef struct operand {
+    int type; 
+    int value;
+    char *label;
+} operand_t;
 
 typedef struct instruction {
     int opcode;
     int *operands;
+    operand_t *operand_list; 
+    int num_operands;
     struct instruction *next;
 } instruction_t;
 

--- a/players/simple_2.s
+++ b/players/simple_2.s
@@ -1,13 +1,11 @@
 .name "Simple"
 .comment "Let's get started"
 
-l2:		   sti  [Par. Des.]   r1  %:live    %1
-        ;  0b      68                 01    0f      01
-        ; Hex. representation
+l2:	sti   r1  %:live %1
+        ; 0b 68 01 0f 01
           
-         and  [Par. Des.]    r1      %0        r1     
-        ;  06       64       01      00        01
-        ; Hex. representation
+        and   r1   %0  r1     
+        ; 06 64 01 00 01
 
 live:	live %1
-		zjmp %:live
+                zjmp %:live

--- a/src/champion.c
+++ b/src/champion.c
@@ -133,7 +133,7 @@ void run_champion(core_t *vm, champion_t champion) {
     instruction_t *found_inst = &champion.inst[instruction_index];
 
     if (found_inst->opcode < 0 || found_inst->opcode > 16) {
-        printf("Invalid opcode for operands: %d\n", found_inst->opcode);
+        printf("cannot run champion. Invalid opcode for operands: %d\n", found_inst->opcode);
         return;
     }
 


### PR DESCRIPTION
### What was done?

Part of: https://github.com/yogimathius/core-war/issues/70

- fixes parsing and running the simple corefile provided by Gabriel when it gets to label instructions
- more work needed to correctly build label instructions
- added an operand_t struct to properly identify different types of operands

### :tophat: Instructions

- `make`
- `./build/corewar players/simple_2.cor`
- confirm doesn't crash (will run til cycles run out)