### PR TITLE
fix: check target instead of target_type (only 2 args for st)

### DIFF
--- a/src/operations/inst_st.c
+++ b/src/operations/inst_st.c
@@ -14,10 +14,10 @@ int inst_st(champion_t *champion, core_t *core, code_t code, int *inst) {
 
   int source_register = inst[0]; // The source register index
   int target = inst[1]; // The target register index or address offset
-  int target_type = inst[2];// The target type (register or address)
 
   // If the target is a register
-  if (target_type & T_REG) {
+  if (target & T_REG) {
+    printf("T_REG is set: %u\n", target);
       champion->registers[target] = champion->registers[source_register];
   } else { 
       // If the target is an address (indirect addressing)

--- a/tests/operations/inst_st_test.c
+++ b/tests/operations/inst_st_test.c
@@ -9,7 +9,7 @@ void inst_st_test(void **state) {
 
     // Setup: Source register (register 1) has a value to be transferred
     champ->registers[1] = 42; 
-    int args[] = {1, 3, 1}; 
+    int args[] = {1, 3}; 
 
     inst_st(champ, core, code, args);
 


### PR DESCRIPTION
### What was done?

`inst_st` only takes 2 args, so crashes when trying to read the 3rd one. This only happens when trying to run the vm with programs that have `st` as an instruction but only 2 args. The test suite doesn't fail since we are properly loading it up with 3 args. Fixing that as well.

### :tophat: Instructions

- `make`
- `./build/corewar players/simple.cor players/simple_extra_lives.cor players/simple.cor players/simple_2.cor`
- should not crash