### PR TITLE
feat: prototype running full instructions from core memory

### DIFF
--- a/include/champion.h
+++ b/include/champion.h
@@ -7,6 +7,7 @@
 
 #include "op.h"
 #include "instructions.h"
+#include "vm.h"
 
 champion_t *init_champion();
 

--- a/include/vm.h
+++ b/include/vm.h
@@ -14,4 +14,6 @@ int read_vm(core_t *core_vm, int address);
 
 void write_vm(core_t *core_vm, int address, int value);
 
+void load_instructions(core_t *core);
+
 #endif

--- a/src/champion.c
+++ b/src/champion.c
@@ -9,6 +9,7 @@ void load_champions(core_t *core_vm, int ac, char **av) {
     add_champion(core_vm, champ);
     ac--;
   }
+  load_instructions(core_vm);
 }
 
 champion_t *init_champion() {

--- a/src/game.c
+++ b/src/game.c
@@ -136,12 +136,15 @@ void run_champions(core_t *vm) {
 
 void run_instructions_from_core(core_t *core_vm) {
     for (int i = 0; i < core_vm->champion_count; i++) {
-        printf("champion count: %d\n", core_vm->champion_count);
-        printf("Running instructions for champion: %d\n", i);
+        if (core_vm->champions[i].dead) {
+            print_colored_text(37);
+            printf("Champion P%d has no lives left. Cannot run.\n", core_vm->champions[i].id);
+            printf("\033[0m");
+            continue;
+        }
         int start_index = i * (MEM_SIZE / core_vm->champion_count);
         for (int j = 0; j < core_vm->champions[i].instruction_size; j++) {
             int champ_index = start_index + j;
-            printf("champion count: %d\n", core_vm->champion_count);
             printf("champ_index: %d\n", champ_index);
             printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
             printf("instruction opcode: %d\n", core_vm->champions[i].inst[j].opcode);
@@ -159,19 +162,18 @@ void run_instructions_from_core(core_t *core_vm) {
 
 void run_game(core_t *core_vm) {
     printf("\n\n====================START GAME=====================\n");
-    // int game_loop_number = 0;
+    int game_loop_number = 0;
 
+
+    while (1) {
+        printf("===============GAME LOOP %d===============\n\n", game_loop_number);
+        // run_champions(core_vm);
+        // core_vm->instruction_pointer++;
         run_instructions_from_core(core_vm);
+        game_loop_number++;
+        if (game_over(core_vm)) {
+            break;
+        }
 
-    // while (1) {
-    //     printf("===============GAME LOOP %d===============\n\n", game_loop_number);
-    //     // run_champions(core_vm);
-    //     // core_vm->instruction_pointer++;
-    //     // if (game_over(core_vm)) {
-    //     //     break;
-    //     // }
-    //     run_instructions_from_core(core_vm);
-    //     game_loop_number++;
-
-    // }
+    }
 }

--- a/src/game.c
+++ b/src/game.c
@@ -138,11 +138,6 @@ void run_instruction(int i, core_t *core_vm, champion_t champion, int instructio
         printf("Invalid opcode for operands: %d\n", opcode);
         return;
     }
-    printf("Found instruction for opcode: %d\n", opcode);
-    printf("instruction index: %d\n", instruction_index);
-    printf("inst opcode: %d\n", champion.inst[instruction_index].opcode);
-    printf("instruction pointer: %d\n", core_vm->instruction_pointer);
-    printf("start index: %d\n", start_index);
     execute_instruction(core_vm, &champion, opcode, champion.inst[instruction_index].operands);
 }
 

--- a/src/game.c
+++ b/src/game.c
@@ -134,17 +134,44 @@ void run_champions(core_t *vm) {
     }
 }
 
-void run_game(core_t *core_vm) {
-    printf("\n\n====================START GAME=====================\n");
-    int game_loop_number = 0;
-
-    while (1) {
-        printf("===============GAME LOOP %d===============\n\n", game_loop_number);
-        run_champions(core_vm);
-        game_loop_number++;
-        core_vm->instruction_pointer++;
-        if (game_over(core_vm)) {
-            break;
+void run_instructions_from_core(core_t *core_vm) {
+    for (int i = 0; i < core_vm->champion_count; i++) {
+        printf("champion count: %d\n", core_vm->champion_count);
+        printf("Running instructions for champion: %d\n", i);
+        int start_index = i * (MEM_SIZE / core_vm->champion_count);
+        for (int j = 0; j < core_vm->champions[i].instruction_size; j++) {
+            int champ_index = start_index + j;
+            printf("champion count: %d\n", core_vm->champion_count);
+            printf("champ_index: %d\n", champ_index);
+            printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
+            printf("instruction opcode: %d\n", core_vm->champions[i].inst[j].opcode);
+            int opcode = core_vm->memory[champ_index];
+            if (opcode < 0 || opcode > 16) {
+                printf("Invalid opcode for operands: %d\n", opcode);
+                continue;
+            }
+            printf("Found instruction for opcode: %d\n", opcode);
+            execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[j].operands);
+            // }
         }
     }
+}
+
+void run_game(core_t *core_vm) {
+    printf("\n\n====================START GAME=====================\n");
+    // int game_loop_number = 0;
+
+        run_instructions_from_core(core_vm);
+
+    // while (1) {
+    //     printf("===============GAME LOOP %d===============\n\n", game_loop_number);
+    //     // run_champions(core_vm);
+    //     // core_vm->instruction_pointer++;
+    //     // if (game_over(core_vm)) {
+    //     //     break;
+    //     // }
+    //     run_instructions_from_core(core_vm);
+    //     game_loop_number++;
+
+    // }
 }

--- a/src/game.c
+++ b/src/game.c
@@ -136,18 +136,20 @@ void run_champions(core_t *vm) {
 
 void run_instruction(int i, core_t *core_vm) {
     int start_index = i * (MEM_SIZE / core_vm->champion_count);
-    for (int j = 0; j < core_vm->champions[i].instruction_size; j++) {
-        int champ_index = start_index + j;
-        printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
-        printf("instruction opcode: %d\n", core_vm->champions[i].inst[j].opcode);
-        int opcode = core_vm->memory[champ_index];
-        if (opcode < 0 || opcode > 16) {
-            printf("Invalid opcode for operands: %d\n", opcode);
-            continue;
-        }
-        printf("Found instruction for opcode: %d\n", opcode);
-        execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[j].operands);
+    int instruction_size = core_vm->champions[i].instruction_size;
+    int instruction_pointer = core_vm->instruction_pointer;
+
+    int instruction_index = instruction_pointer >= instruction_size ? (instruction_pointer % instruction_size) : instruction_pointer;
+    int champ_index = start_index + instruction_index;
+    printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
+    printf("instruction opcode: %d\n", core_vm->champions[i].inst[instruction_index].opcode);
+    int opcode = core_vm->memory[champ_index];
+    if (opcode < 0 || opcode > 16) {
+        printf("Invalid opcode for operands: %d\n", opcode);
+        return;
     }
+    printf("Found instruction for opcode: %d\n", opcode);
+    execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[instruction_index].operands);
 }
 
 void run_instructions_from_core(core_t *core_vm) {
@@ -170,9 +172,9 @@ void run_game(core_t *core_vm) {
     while (1) {
         printf("===============GAME LOOP %d===============\n\n", game_loop_number);
         // run_champions(core_vm);
-        // core_vm->instruction_pointer++;
         run_instructions_from_core(core_vm);
         game_loop_number++;
+        core_vm->instruction_pointer++;
         if (game_over(core_vm)) {
             break;
         }

--- a/src/game.c
+++ b/src/game.c
@@ -129,8 +129,24 @@ void run_champions(core_t *vm) {
             printf("Champion P%d has no lives left. Cannot run.\n", vm->champions[i].id);
             printf("\033[0m");
       } else {
-        run_champion(vm, vm->champions[i]);
+            run_champion(vm, vm->champions[i]);
       }
+    }
+}
+
+void run_instruction(int i, core_t *core_vm) {
+    int start_index = i * (MEM_SIZE / core_vm->champion_count);
+    for (int j = 0; j < core_vm->champions[i].instruction_size; j++) {
+        int champ_index = start_index + j;
+        printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
+        printf("instruction opcode: %d\n", core_vm->champions[i].inst[j].opcode);
+        int opcode = core_vm->memory[champ_index];
+        if (opcode < 0 || opcode > 16) {
+            printf("Invalid opcode for operands: %d\n", opcode);
+            continue;
+        }
+        printf("Found instruction for opcode: %d\n", opcode);
+        execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[j].operands);
     }
 }
 
@@ -140,22 +156,8 @@ void run_instructions_from_core(core_t *core_vm) {
             print_colored_text(37);
             printf("Champion P%d has no lives left. Cannot run.\n", core_vm->champions[i].id);
             printf("\033[0m");
-            continue;
-        }
-        int start_index = i * (MEM_SIZE / core_vm->champion_count);
-        for (int j = 0; j < core_vm->champions[i].instruction_size; j++) {
-            int champ_index = start_index + j;
-            printf("champ_index: %d\n", champ_index);
-            printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
-            printf("instruction opcode: %d\n", core_vm->champions[i].inst[j].opcode);
-            int opcode = core_vm->memory[champ_index];
-            if (opcode < 0 || opcode > 16) {
-                printf("Invalid opcode for operands: %d\n", opcode);
-                continue;
-            }
-            printf("Found instruction for opcode: %d\n", opcode);
-            execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[j].operands);
-            // }
+        } else {
+            run_instruction(i, core_vm);
         }
     }
 }

--- a/src/game.c
+++ b/src/game.c
@@ -122,18 +122,6 @@ void run_champion(core_t *vm, champion_t champion) {
     execute_instruction(vm, &champion, found_inst->opcode, found_inst->operands);
 }
 
-void run_champions(core_t *vm) {
-    for (int i = 0; i < vm->champion_count; i++) {
-      if (vm->champions[i].dead) {
-            print_colored_text(37);
-            printf("Champion P%d has no lives left. Cannot run.\n", vm->champions[i].id);
-            printf("\033[0m");
-      } else {
-            run_champion(vm, vm->champions[i]);
-      }
-    }
-}
-
 void run_instruction(int i, core_t *core_vm) {
     int start_index = i * (MEM_SIZE / core_vm->champion_count);
     int instruction_size = core_vm->champions[i].instruction_size;
@@ -141,8 +129,7 @@ void run_instruction(int i, core_t *core_vm) {
 
     int instruction_index = instruction_pointer >= instruction_size ? (instruction_pointer % instruction_size) : instruction_pointer;
     int champ_index = start_index + instruction_index;
-    printf("instruction_size: %d\n", core_vm->champions[i].instruction_size);
-    printf("instruction opcode: %d\n", core_vm->champions[i].inst[instruction_index].opcode);
+
     int opcode = core_vm->memory[champ_index];
     if (opcode < 0 || opcode > 16) {
         printf("Invalid opcode for operands: %d\n", opcode);
@@ -152,7 +139,7 @@ void run_instruction(int i, core_t *core_vm) {
     execute_instruction(core_vm, &core_vm->champions[i], opcode, core_vm->champions[i].inst[instruction_index].operands);
 }
 
-void run_instructions_from_core(core_t *core_vm) {
+void run_instructions(core_t *core_vm) {
     for (int i = 0; i < core_vm->champion_count; i++) {
         if (core_vm->champions[i].dead) {
             print_colored_text(37);
@@ -171,13 +158,11 @@ void run_game(core_t *core_vm) {
 
     while (1) {
         printf("===============GAME LOOP %d===============\n\n", game_loop_number);
-        // run_champions(core_vm);
-        run_instructions_from_core(core_vm);
+        run_instructions(core_vm);
         game_loop_number++;
         core_vm->instruction_pointer++;
         if (game_over(core_vm)) {
             break;
         }
-
     }
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -58,11 +58,6 @@ void add_champion(core_t *core_t, champion_t *champion) {
   champion->registers[0] = champion->id;
   champion->color = champ_color[champion->id - 1];
   core_t->champions[core_t->champion_count - 1] = *champion;
-  for (int i = 0; i < champion->instruction_size; i++) {
-    printf("\n\nAdding instruction: %d\n", champion->inst[i].opcode);
-    printf("to memory: %d\n\n", i + (MEM_SIZE / core_t->champion_count) * (core_t->champion_count - 1));
-    core_t->memory[i + (MEM_SIZE / core_t->champion_count) * (core_t->champion_count - 1)] = champion->inst[i].opcode;
-  }
 }
 
 void load_instructions(core_t *core) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -69,8 +69,6 @@ void load_instructions(core_t *core) {
     for (int i = 0; i < core->champion_count; i++) {
         champion_t *champion = &core->champions[i];
         for (int j = 0; j < champion->instruction_size; j++) {
-            printf("\n\nAdding instruction: %d\n", champion->inst[i].opcode);
-            printf("to memory: %d\n\n", i + (MEM_SIZE / core->champion_count) * (core->champion_count - 1));
             core->memory[j + (MEM_SIZE / core->champion_count) * i] = champion->inst[j].opcode;
         }
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -59,8 +59,21 @@ void add_champion(core_t *core_t, champion_t *champion) {
   champion->color = champ_color[champion->id - 1];
   core_t->champions[core_t->champion_count - 1] = *champion;
   for (int i = 0; i < champion->instruction_size; i++) {
+    printf("\n\nAdding instruction: %d\n", champion->inst[i].opcode);
+    printf("to memory: %d\n\n", i + (MEM_SIZE / core_t->champion_count) * (core_t->champion_count - 1));
     core_t->memory[i + (MEM_SIZE / core_t->champion_count) * (core_t->champion_count - 1)] = champion->inst[i].opcode;
   }
+}
+
+void load_instructions(core_t *core) {
+    for (int i = 0; i < core->champion_count; i++) {
+        champion_t *champion = &core->champions[i];
+        for (int j = 0; j < champion->instruction_size; j++) {
+            printf("\n\nAdding instruction: %d\n", champion->inst[i].opcode);
+            printf("to memory: %d\n\n", i + (MEM_SIZE / core->champion_count) * (core->champion_count - 1));
+            core->memory[j + (MEM_SIZE / core->champion_count) * i] = champion->inst[j].opcode;
+        }
+    }
 }
 
 int add_champion_to_core(core_t* core, champion_t* champion) {


### PR DESCRIPTION
### What was done?

- loaded opcodes into memory with dynamic indexing based on champion count
- use same indexing to lookup instructions for execution in game loop

### :tophat: Instructions

- `make`
- `./build/corewar players/simple_extra_lives.cor players/simple_2.cor`

### TODO

- load operands as well as opcodes in memory
- handle labels and jumps in the same place (memory)
- cleanup instruction list in champion?
- update fork and lfork to also be loaded into memory
- ~probably~ DEFINITELY more that I can't think of 😆 