### PR TITLE
feat: parse args for -n and -dump

### DIFF
--- a/include/op.h
+++ b/include/op.h
@@ -144,6 +144,7 @@ typedef struct core_s {
     champion_t champions[MAX_CHAMPIONS];
     int lives;
     int winner;
+    int dump;
     process_t *process;
 } core_t;
 
@@ -278,9 +279,10 @@ corresponding to the ASCII code of the content of the register (in base
 */
 int inst_aff(champion_t *, core_t *, code_t, int *);
 
-
 void print_colored_text(int color);
 
 void display_memory(const core_t *core);
+
+void parse_args(core_t *core_vm, int ac, char **av);
 
 #endif

--- a/src/champion.c
+++ b/src/champion.c
@@ -28,6 +28,7 @@ champion_t *init_champion() {
     const instruction_t *inst = malloc(sizeof(instruction_t));
     champ->inst[i] = *inst;
   }
+  champ->id = 0;
 	return champ;
 }
 

--- a/src/corewar.c
+++ b/src/corewar.c
@@ -10,8 +10,7 @@ int main(int ac, char **av) {
         exit(1);
     }
     core_t *core_vm = init_vm();
-    
-    load_champions(core_vm, ac, av);
+    parse_args(core_vm, ac, av);
 
     run_game(core_vm);
 

--- a/src/game.c
+++ b/src/game.c
@@ -64,6 +64,10 @@ void reset_champ_counters(core_t *core_vm) {
 }
 
 int game_on(core_t *core_vm) {
+    if (core_vm->dump > 0 && core_vm->nbr_cycles >= core_vm->dump) {
+        printf("Dumping memory at cycle %d\n", core_vm->nbr_cycles);
+        display_memory(core_vm);
+    }
     if (core_vm->lives >= NBR_LIVE || core_vm->nbr_cycles >= core_vm->cycle_to_die) {
         printf("Live count maxed out. Decreasing cycle to die by %d\n", CYCLE_DELTA);
         // display_memory(core_vm);

--- a/src/parse_args.c
+++ b/src/parse_args.c
@@ -1,0 +1,50 @@
+#include <op.h>
+#include <instructions.h>
+#include <champion.h>
+#include <vm.h>
+
+void parse_args(core_t *core_vm, int ac, char **av) {
+    if (ac < 2) {
+        printf("Usage: ./corewar [champion1.cor] [champion2.cor] [champion3.cor] [champion4.cor]\n");
+        exit(1);
+    }
+
+    int set_id;
+    printf("ac: %d\n", ac);
+    for (int i = 1; i < ac; i++) {
+      printf("av[i]: %s\n", av[i]);
+        if (strstr(av[i], "-") != NULL){
+            if (strcmp(av[i], "-dump") == 0) {
+                if (i + 1 < ac) {
+                    core_vm->dump = atoi(av[i + 1]);
+                    i++;
+                } else {
+                    printf("Invalid dump value\n");
+                    exit(1);
+                }
+            } else if (strcmp(av[i], "-n") == 0) {
+                if (i + 1 < ac) {
+                    set_id = atoi(av[i + 1]);
+                    i++;
+                } else {
+                    printf("Invalid champion id\n");
+                    exit(1);
+                }
+            } else {
+                printf("Invalid argument: %s\n", av[i]);
+                exit(1);
+            }
+        } else if (strstr(av[i], ".cor") != NULL) {
+            printf("Loading champion: %s\n", av[i]);
+            champion_t *champ = init_champion();
+            if (set_id) {
+                champ->id = set_id;
+                set_id = 0;
+            }
+            create_champion(champ, av[i ]);
+            add_champion(core_vm, champ);
+        }
+    }
+    load_instructionsv2(core_vm);
+    build_processes(core_vm);
+}

--- a/src/vm.c
+++ b/src/vm.c
@@ -25,6 +25,7 @@ core_t *init_vm() {
     core->lives = 0;
     core->winner = 0;
     core->process = NULL;
+    core->dump = 0;
 
     return core;
 }
@@ -52,7 +53,7 @@ void add_champion(core_t *core_t, champion_t *champion) {
   const int champ_color[4] = {31, 32, 35, 36};
 
   core_t->champion_count+=1;
-  champion->id = core_t->champion_count;
+  champion->id = champion->id != 0 ? champion->id : core_t->champion_count;
   champion->counter = 0;
   champion->carry_flag = 0;
   champion->registers[0] = champion->id;

--- a/src/vm.c
+++ b/src/vm.c
@@ -57,7 +57,7 @@ void add_champion(core_t *core_t, champion_t *champion) {
   champion->counter = 0;
   champion->carry_flag = 0;
   champion->registers[0] = champion->id;
-  champion->color = champ_color[champion->id - 1];
+  champion->color = champ_color[core_t->champion_count - 1];
   core_t->champions[core_t->champion_count - 1] = *champion;
 }
 


### PR DESCRIPTION
### What was done?

closes https://github.com/yogimathius/core-war/issues/81
closes https://github.com/yogimathius/core-war/issues/82

### :tophat: Instructions

- `make`
- `./build/corewar players/simple_extra_lives.cor -n 6 players/simple.cor -dump 15`
- will set simple.core to p6 and dump every 15 cycles

### TODO

- [follow ticket ](https://github.com/yogimathius/core-war/issues/114 )created to fix `display_memory` function